### PR TITLE
Use fewer DataSource objects.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compileOnly group: 'javax.persistence', name: 'persistence-api', version: '1.0.2'
     compile group: 'org.axonframework', name: 'axon-core', version: axonVersion
 
-    compile group: 'com.loginbox.mybatis', name: 'dropwizard-mybatis', version: '1.0.0'
+    compile group: 'com.loginbox.mybatis', name: 'dropwizard-mybatis', version: '1.2.1'
 
     compile group: 'com.loginbox.heroku', name: 'dropwizard-heroku-config', version: '1.0.0'
     compile group: 'com.loginbox.heroku', name: 'dropwizard-heroku-db', version: '1.0.0'

--- a/app/src/main/java/com/unreasonent/ds/DistantShore.java
+++ b/app/src/main/java/com/unreasonent/ds/DistantShore.java
@@ -1,5 +1,6 @@
 package com.unreasonent.ds;
 
+import com.loginbox.dropwizard.mybatis.DatasourceMybatisBundle;
 import com.loginbox.dropwizard.mybatis.MybatisBundle;
 import com.unreasonent.ds.auth.AuthBundle;
 import com.unreasonent.ds.axon.AxonBundle;
@@ -7,6 +8,7 @@ import com.unreasonent.ds.cors.CorsBundle;
 import com.unreasonent.ds.database.DatabaseBundle;
 import com.unreasonent.ds.squad.SquadBundle;
 import io.dropwizard.Application;
+import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
@@ -36,11 +38,11 @@ public class DistantShore extends Application<DistantShoreConfiguration> {
             = new AuthBundle();
     private final DatabaseBundle databaseBundle
             = new DatabaseBundle();
-    private final MybatisBundle<DistantShoreConfiguration> mybatisBundle
-            = new MybatisBundle<DistantShoreConfiguration>("com.unreasonent.ds") {
+    private final DatasourceMybatisBundle mybatisBundle
+            = new DatasourceMybatisBundle("com.unreasonent.ds") {
         @Override
-        public PooledDataSourceFactory getDataSourceFactory(DistantShoreConfiguration configuration) {
-            return configuration.getDatabase();
+        protected DataSource getDataSource() {
+            return databaseBundle.getDataSource();
         }
     };
     private final MigrationsBundle<DistantShoreConfiguration> migrationsBundle

--- a/app/src/test/java/com/unreasonent/ds/DistantShoreTest.java
+++ b/app/src/test/java/com/unreasonent/ds/DistantShoreTest.java
@@ -1,5 +1,6 @@
 package com.unreasonent.ds;
 
+import com.loginbox.dropwizard.mybatis.DatasourceMybatisBundle;
 import com.loginbox.dropwizard.mybatis.MybatisBundle;
 import com.unreasonent.ds.auth.AuthBundle;
 import com.unreasonent.ds.axon.AxonBundle;
@@ -34,7 +35,7 @@ public class DistantShoreTest {
         verify(bootstrap).addBundle(argThat(isA(CorsBundle.class)));
         verify(bootstrap).addBundle(argThat(isA(AuthBundle.class)));
         verify(bootstrap).addBundle(argThat(isA(DatabaseBundle.class)));
-        verify(bootstrap).addBundle(argThat(isA(MybatisBundle.class)));
+        verify(bootstrap).addBundle(argThat(wrapsBundle(isA(DatasourceMybatisBundle.class))));
         verify(bootstrap).addBundle(argThat(wrapsBundle(isA(MigrationsBundle.class))));
         verify(bootstrap).addBundle(argThat(wrapsBundle(isA(AxonBundle.class))));
         verify(bootstrap).addBundle(argThat(wrapsBundle(isA(SquadBundle.class))));


### PR DESCRIPTION
Rather than giving Mybatis and Axon independent datasources to play in, use the
same source for both. This dramatically simplifies connection management.