### PR TITLE
Deduplicate squad changes.

### DIFF
--- a/app/src/main/java/com/unreasonent/ds/squad/models/PlayerOwnedSquad.java
+++ b/app/src/main/java/com/unreasonent/ds/squad/models/PlayerOwnedSquad.java
@@ -7,6 +7,8 @@ import org.axonframework.eventhandling.annotation.EventHandler;
 import org.axonframework.eventsourcing.annotation.AbstractAnnotatedAggregateRoot;
 import org.axonframework.eventsourcing.annotation.AggregateIdentifier;
 
+import java.util.Objects;
+
 public class PlayerOwnedSquad extends AbstractAnnotatedAggregateRoot<String> {
     private static final long serialVersionUID = 0;
 
@@ -15,7 +17,9 @@ public class PlayerOwnedSquad extends AbstractAnnotatedAggregateRoot<String> {
     private Squad squad;
 
     public void updateSquad(UpdateSquadCommand command) {
-        apply(new SquadUpdatedEvent(command.getUserId(), command.getSquad()));
+        Squad squad = command.getSquad();
+        if (!Objects.equals(this.squad, squad))
+            apply(new SquadUpdatedEvent(command.getUserId(), squad));
     }
 
     @EventHandler

--- a/app/src/test/java/com/unreasonent/ds/squad/models/UpdateSquadHandlerTest.java
+++ b/app/src/test/java/com/unreasonent/ds/squad/models/UpdateSquadHandlerTest.java
@@ -32,10 +32,20 @@ public class UpdateSquadHandlerTest {
 
     @Test
     public void updateModifiesSquads() {
+        Squad originalSquad = mock(Squad.class);
+        Squad newSquad = mock(Squad.class);
+        UpdateSquadCommand command = new UpdateSquadCommand("userid", newSquad);
+        fixture.given(new SquadUpdatedEvent("userid", originalSquad))
+                .when(command)
+                .expectEvents(new SquadUpdatedEvent("userid", newSquad));
+    }
+
+    @Test
+    public void identicalUpdateEmitsNothing() {
         Squad squad = mock(Squad.class);
         UpdateSquadCommand command = new UpdateSquadCommand("userid", squad);
         fixture.given(new SquadUpdatedEvent("userid", squad))
                 .when(command)
-                .expectEvents(new SquadUpdatedEvent("userid", squad));
+                .expectEvents();
     }
 }


### PR DESCRIPTION
When re-saving a squad identical to the user's current squad, do nothing. Don't
even record an event - it's a waste of space.